### PR TITLE
Minor fixes and hints

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,6 +15,13 @@ To turn on smart quotes minor mode in all text mode buffers, use::
 
     (add-hook 'text-mode-hook 'turn-on-smart-quotes)
 
+To support spell checkers when using a curly right quote as an apostrophe,
+customize ``ispell-local-dictionary-alist``, adding for example::
+
+ (quote (("british" "[[:alpha:]]" "[^[:alpha:]]" "['’]" t ("-d" "en_GB") nil utf-8)))
+
+This dictionary’s value can then be set as the name of ``ispell-local-dictionary``.
+
 
 Usage
 -----

--- a/smart-quotes.el
+++ b/smart-quotes.el
@@ -56,7 +56,7 @@ otherwise.  If `smart-quotes-reverse-quotes' is true, and point is
 preceded by a single left or right quote, reverse its direction
 instead of inserting another.  A prefix ARG prevents reversal."
   (interactive "P")
-  (ucs-insert
+  (insert-char
    (or (if (and (not noreverse) smart-quotes-reverse-quotes)
            (if (= (preceding-char) #x2018)
                (progn (delete-char -1) #x2019)
@@ -72,7 +72,7 @@ point is preceded by a double left or right quote, reverse its
 direction instead of inserting another.  A prefix ARG prevents
 reversal."
   (interactive "P")
-  (ucs-insert
+  (insert-char
    (or (if (and (not noreverse) smart-quotes-reverse-quotes)
            (if (= (preceding-char) #x201C)
                (progn (delete-char -1) #x201D)


### PR DESCRIPTION
Two changes:
1. Use `insert-char` instead of obsolete `ucs-insert`
2. Add a hint on placating spelling checkers.
