### PR TITLE
Feature: Include neutral quotes in cycle

### DIFF
--- a/smart-quotes.el
+++ b/smart-quotes.el
@@ -61,7 +61,9 @@ instead of inserting another.  A prefix ARG prevents reversal."
            (if (= (preceding-char) #x2018)
                (progn (delete-char -1) #x2019)
              (if (= (preceding-char) #x2019)
-                 (progn (delete-char -1) #x2018))))
+                 (progn (delete-char -1) #x0027)
+               (if (= (preceding-char) #x0027)
+                 (progn (delete-char -1) #x2018)))))
        (if (looking-back smart-quotes-left-context) #x2018 #x2019))))
 
 (defun smart-quotes-insert-double (&optional noreverse)
@@ -77,7 +79,9 @@ reversal."
            (if (= (preceding-char) #x201C)
                (progn (delete-char -1) #x201D)
              (if (= (preceding-char) #x201D)
-                 (progn (delete-char -1) #x201C))))
+                 (progn (delete-char -1) #x0022)
+               (if (= (preceding-char) #x0022)
+                 (progn (delete-char -1) #x201C)))))
        (if (looking-back smart-quotes-left-context) #x201C #x201D))))
 
 ;;;###autoload

--- a/smart-quotes.el
+++ b/smart-quotes.el
@@ -51,10 +51,11 @@ another character."
 
 (defun smart-quotes-insert-single (&optional nocycle)
   "Insert U+2018 LEFT SINGLE QUOTATION MARK if point is preceded
-by `smart-quotes-left-context'; U+2019 RIGHT SINGLE QUOTATION MARK
-otherwise.  If `smart-quotes-reverse-quotes' is true, and point is
-preceded by a single left or right quote, reverse its direction
-instead of inserting another.  A prefix ARG prevents reversal."
+by `smart-quotes-left-context'; U+2019 RIGHT SINGLE QUOTATION
+MARK otherwise.  If `smart-quotes-cycle-quotes' is true, and
+point is preceded by a single left quote, a single right quote,
+or an APOSTROPHE (U+0027), then cycle around those characters
+instead of inserting anything.  A prefix ARG prevents cycling."
   (interactive "P")
   (insert-char
    (or (if (and (not nocycle) smart-quotes-cycle-quotes)
@@ -69,10 +70,10 @@ instead of inserting another.  A prefix ARG prevents reversal."
 (defun smart-quotes-insert-double (&optional nocycle)
   "Insert U+201C LEFT DOUBLE QUOTATION MARK if point is preceded
 by `smart-quotes-left-context'; U+201D RIGHT DOUBLE QUOTATION
-MARK otherwise.  If `smart-quotes-reverse-quotes' is true, and
-point is preceded by a double left or right quote, reverse its
-direction instead of inserting another.  A prefix ARG prevents
-reversal."
+MARK otherwise.  If `smart-quotes-cycle-quotes' is true, and
+point is preceded by a double left quote, a double right quote,
+or a QUOTATION MARK (U+0022), cycle around those characters
+instead of inserting anything.  A prefix ARG prevents cycling."
   (interactive "P")
   (insert-char
    (or (if (and (not nocycle) smart-quotes-cycle-quotes)

--- a/smart-quotes.el
+++ b/smart-quotes.el
@@ -43,13 +43,13 @@ contexts, a right quotation mark will be inserted."
   :type 'regexp
   :group 'smart-quotes)
 
-(defcustom smart-quotes-reverse-quotes t
-  "If non-nil, reverse a preceding quote instead of inserting a
-quote of the same kind."
+(defcustom smart-quotes-cycle-quotes t
+  "If non-nil, cycle a preceding quote instead of inserting
+another character."
   :type 'boolean
   :group 'smart-quotes)
 
-(defun smart-quotes-insert-single (&optional noreverse)
+(defun smart-quotes-insert-single (&optional nocycle)
   "Insert U+2018 LEFT SINGLE QUOTATION MARK if point is preceded
 by `smart-quotes-left-context'; U+2019 RIGHT SINGLE QUOTATION MARK
 otherwise.  If `smart-quotes-reverse-quotes' is true, and point is
@@ -57,7 +57,7 @@ preceded by a single left or right quote, reverse its direction
 instead of inserting another.  A prefix ARG prevents reversal."
   (interactive "P")
   (insert-char
-   (or (if (and (not noreverse) smart-quotes-reverse-quotes)
+   (or (if (and (not nocycle) smart-quotes-cycle-quotes)
            (if (= (preceding-char) #x2018)
                (progn (delete-char -1) #x2019)
              (if (= (preceding-char) #x2019)
@@ -66,7 +66,7 @@ instead of inserting another.  A prefix ARG prevents reversal."
                  (progn (delete-char -1) #x2018)))))
        (if (looking-back smart-quotes-left-context) #x2018 #x2019))))
 
-(defun smart-quotes-insert-double (&optional noreverse)
+(defun smart-quotes-insert-double (&optional nocycle)
   "Insert U+201C LEFT DOUBLE QUOTATION MARK if point is preceded
 by `smart-quotes-left-context'; U+201D RIGHT DOUBLE QUOTATION
 MARK otherwise.  If `smart-quotes-reverse-quotes' is true, and
@@ -75,7 +75,7 @@ direction instead of inserting another.  A prefix ARG prevents
 reversal."
   (interactive "P")
   (insert-char
-   (or (if (and (not noreverse) smart-quotes-reverse-quotes)
+   (or (if (and (not nocycle) smart-quotes-cycle-quotes)
            (if (= (preceding-char) #x201C)
                (progn (delete-char -1) #x201D)
              (if (= (preceding-char) #x201D)


### PR DESCRIPTION
I'm finding this library very useful for working with LaTeX files; thanks!  Sometimes I need to include verbatim code snippets, and this often involves actual APOSTROPHE (U+0027) or QUOTATION MARK (U+0022) characters.  This PR extends the 'reverse' behaviour to a 'cycle' between left, right, and neutral in both single and double flavours, allowing easier typing of material involving mixed smart/neutral quotes.